### PR TITLE
Small log fix

### DIFF
--- a/scripting/clear_nickname.sp
+++ b/scripting/clear_nickname.sp
@@ -601,7 +601,7 @@ Action Event_NameChanged(Event event, const char[] name, bool dontBroadcast)
 		if(Result == Plugin_Changed)
 		{
 			PrintToChat(iClient, "%t%t", "ChatPrefix", "AutoAdvertFound", iCountKey);
-			LogToFile(g_sLogPath, "%T", "AutoAdvertFound", LANG_SERVER, sOldName, sNewName, iCountKey);
+			LogToFile(g_sLogPath, "%T", "AutoAdvertFound", LANG_SERVER, iCountKey);
 
 			SetClientName(iClient, sNewName);
 


### PR DESCRIPTION
Fix - [clear_nickname.smx] AUTO: Ваш никнейм имел 1933667919 запрещенных ключей.
It output the (what?) and not the keycount